### PR TITLE
Update to use Xft for text drawing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX=g++
 CXXFLAGS=-Os -Wall
 LIBS=-lX11 -lXft -lfontconfig
-INCLUDES=-I/usr/include/freetype2
+INCLUDES=`pkg-config --cflags fontconfig`
 
 BIN=rpbar rpbarsend
 

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,28 @@
 CXX=g++
 CXXFLAGS=-Os -Wall
-LIBS=-lX11
+LIBS=-lX11 -lXft -lfontconfig
+INCLUDES=-I/usr/include/freetype2
 
 BIN=rpbar rpbarsend
 
 all: ${BIN}
 
 .cc.o:
-	@${CXX} -c ${CXXFLAGS} $<
+	${CXX} -c ${CXXFLAGS} $<
 
-rpbar.o: rpbar.cc rpbar.hh settings.hh
+rpbar.o: rpbar.cc rpbar.hh settings.hh drw.h
+	${CXX} -c ${CXXFLAGS} ${INCLUDES} $<
 
-rpbar: rpbar.o
+drw.o: drw.c drw.h
+	${CXX} -c ${CXXFLAGS} drw.c
+
+rpbar: rpbar.o drw.o
 	${CXX} -o $@ $^ ${LIBS}
 
 rpbarsend.o: rpbarsend.cc
 
 rpbarsend: rpbarsend.o settings.hh
-	${CXX} -o $@ $^ ${LIBS}
+	${CXX} -o $@ $^
 
 clean:
 	rm -f *.o ${BIN}

--- a/drw.c
+++ b/drw.c
@@ -1,0 +1,87 @@
+/*
+Extracted from dmenu drw.h
+
+MIT/X Consortium License
+
+© 2006-2014 Anselm R Garbe <anselm@garbe.us>
+© 2010-2012 Connor Lane Smith <cls@lubutu.com>
+© 2009 Gottox <gottox@s01.de>
+© 2009 Markus Schnalke <meillo@marmaro.de>
+© 2009 Evan Gates <evan.gates@gmail.com>
+© 2006-2008 Sander van Dijk <a dot h dot vandijk at gmail dot com>
+© 2006-2007 Michał Janeczek <janeczek at gmail dot com>
+© 2014-2015 Hiltjo Posthuma <hiltjo@codemadness.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+ */
+
+#include "drw.h"
+
+#define BETWEEN(X, A, B)        ((A) <= (X) && (X) <= (B))
+#define UTF_INVALID 0xFFFD
+
+static const unsigned char utfmask[UTF_SIZ + 1] = {0xC0, 0x80, 0xE0, 0xF0, 0xF8};
+static const unsigned char utfbyte[UTF_SIZ + 1] = {0x80,    0, 0xC0, 0xE0, 0xF0};
+static const long utfmin[UTF_SIZ + 1] = {       0,    0,  0x80,  0x800,  0x10000};
+static const long utfmax[UTF_SIZ + 1] = {0x10FFFF, 0x7F, 0x7FF, 0xFFFF, 0x10FFFF};
+
+static long
+utf8decodebyte(const char c, size_t *i)
+{
+	for (*i = 0; *i < (UTF_SIZ + 1); ++(*i))
+		if (((unsigned char)c & utfmask[*i]) == utfbyte[*i])
+			return (unsigned char)c & ~utfmask[*i];
+	return 0;
+}
+
+static size_t
+utf8validate(long *u, size_t i)
+{
+	if (!BETWEEN(*u, utfmin[i], utfmax[i]) || BETWEEN(*u, 0xD800, 0xDFFF))
+		*u = UTF_INVALID;
+	for (i = 1; *u > utfmax[i]; ++i)
+		;
+	return i;
+}
+
+size_t
+utf8decode(const char *c, long *u, size_t clen)
+{
+	size_t i, j, len, type;
+	long udecoded;
+
+	*u = UTF_INVALID;
+	if (!clen)
+		return 0;
+	udecoded = utf8decodebyte(c[0], &len);
+	if (!BETWEEN(len, 1, UTF_SIZ))
+		return 1;
+	for (i = 1, j = 1; i < clen && j < len; ++i, ++j) {
+		udecoded = (udecoded << 6) | utf8decodebyte(c[i], &type);
+		if (type)
+			return j;
+	}
+	if (j < len)
+		return 0;
+	*u = udecoded;
+	utf8validate(u, len);
+
+	return len;
+}

--- a/drw.h
+++ b/drw.h
@@ -1,0 +1,45 @@
+/*
+Extracted from dmenu drw.h
+
+MIT/X Consortium License
+
+© 2006-2014 Anselm R Garbe <anselm@garbe.us>
+© 2010-2012 Connor Lane Smith <cls@lubutu.com>
+© 2009 Gottox <gottox@s01.de>
+© 2009 Markus Schnalke <meillo@marmaro.de>
+© 2009 Evan Gates <evan.gates@gmail.com>
+© 2006-2008 Sander van Dijk <a dot h dot vandijk at gmail dot com>
+© 2006-2007 Michał Janeczek <janeczek at gmail dot com>
+© 2014-2015 Hiltjo Posthuma <hiltjo@codemadness.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+ */
+
+#ifndef _DRW_H
+#define _DRW_H
+
+#include <stddef.h>
+
+#define UTF_SIZ 4
+
+size_t
+utf8decode(const char *, long *, size_t);
+
+#endif

--- a/rpbar.cc
+++ b/rpbar.cc
@@ -506,19 +506,19 @@ RpBar::load_font_for_codepoint(long codepoint)
 
   if (!FcPatternAddCharSet(fc_pattern_dup, FC_CHARSET, fc_charset)) {
     FcCharSetDestroy(fc_charset);
-    FcPatternDestroy(fc_pattern);
+    FcPatternDestroy(fc_pattern_dup);
     return NULL;
   }
 
   if (!FcPatternAddBool(fc_pattern_dup, FC_SCALABLE, FcTrue)) {
     FcCharSetDestroy(fc_charset);
-    FcPatternDestroy(fc_pattern);
+    FcPatternDestroy(fc_pattern_dup);
     return NULL;
   }
 
   if (!FcConfigSubstitute(NULL, fc_pattern_dup, FcMatchPattern)) {
     FcCharSetDestroy(fc_charset);
-    FcPatternDestroy(fc_pattern);
+    FcPatternDestroy(fc_pattern_dup);
     return NULL;
   }
 
@@ -531,7 +531,7 @@ RpBar::load_font_for_codepoint(long codepoint)
       &fc_result);
   if (!fc_pattern_match) {
     FcCharSetDestroy(fc_charset);
-    FcPatternDestroy(fc_pattern);
+    FcPatternDestroy(fc_pattern_dup);
     return NULL;
   }
 

--- a/rpbar.cc
+++ b/rpbar.cc
@@ -193,6 +193,7 @@ RpBar::init_font(const char *fontstr) {
   if (!xft_font) {
     throw RpBarException("Font not found");
   }
+
   xft_fonts.push_back(xft_font);
 
   fc_pattern = FcNameParse((FcChar8 *) fontstr);
@@ -510,12 +511,6 @@ RpBar::load_font_for_codepoint(long codepoint)
     return NULL;
   }
 
-  if (!FcPatternAddBool(fc_pattern_dup, FC_SCALABLE, FcTrue)) {
-    FcCharSetDestroy(fc_charset);
-    FcPatternDestroy(fc_pattern_dup);
-    return NULL;
-  }
-
   if (!FcConfigSubstitute(NULL, fc_pattern_dup, FcMatchPattern)) {
     FcCharSetDestroy(fc_charset);
     FcPatternDestroy(fc_pattern_dup);
@@ -572,6 +567,7 @@ void RpBar::select_window(int win_ix) {
 } /* end namespace rpbar */
 
 int main(int argc, const char *argv[]) {
+  setlocale(LC_CTYPE, "");
   rpbar::RpBar rpbar;
   rpbar.run();
 

--- a/rpbar.cc
+++ b/rpbar.cc
@@ -36,6 +36,8 @@
 
 #include <algorithm>
 
+#include "drw.h"
+
 namespace rpbar
 {
 
@@ -49,22 +51,67 @@ unsigned long RpBar::get_color(const char *colstr) {
   return color.pixel;
 }
 
-int RpBar::text_width(const std::string& text) {
-  XRectangle backgnd_rect;
-  if(font.set) {
-    XmbTextExtents(font.set, text.c_str(), text.length(), NULL, &backgnd_rect);
-    return backgnd_rect.width;
+// text_width_in_font determines width of the given text in the given font.
+//
+// You should make sure the font has the characters for the characters you want
+// to know the width of before using this function.
+int
+RpBar::text_width_in_font(XftFont * const xft_font, const char * const text,
+  const int len)
+{
+  if (!xft_font || !text || strlen(text) == 0) {
+    return -1;
   }
-  return XTextWidth(font.xfont, text.c_str(), text.length());
+
+  XGlyphInfo glyph_info;
+  memset(&glyph_info, 0, sizeof(XGlyphInfo));
+
+  XftTextExtentsUtf8(display, xft_font, (FcChar8 *) text, len, &glyph_info);
+
+  return glyph_info.xOff;
+}
+
+// text_width determines the width the text would have if displayed.
+//
+// It uses the same logic used in drawing the text itself, so it may use
+// several fonts.
+int
+RpBar::text_width(const char * const text)
+{
+  if (!text || strlen(text) == 0) {
+    return -1;
+  }
+
+  // x, y, color do not matter in this case.
+  // This points to poor design, but mostly duplicating draw_text() to
+  // get only the width part is not so nice either.
+  const int x = 0;
+  const int y = 0;
+  const char * const color = NULL;
+
+  // Don't actually draw anything.
+  const bool render = false;
+
+  return draw_text(x, y, text, color, render);
 }
 
 RpBar::~RpBar() {
   unlink(socket_path.c_str());
-  if(font.set) {
-    XFreeFontSet(display, font.set);
-  } else {
-    XFreeFont(display, font.xfont);
+
+  if (display) {
+    for (std::vector<XftFont *>::iterator i = xft_fonts.begin();
+        i != xft_fonts.end();
+        i++)
+    {
+      XftFont * xft_font = *i;
+      XftFontClose(display, xft_font);
+    }
   }
+
+  if (fc_pattern) {
+    FcPatternDestroy(fc_pattern);
+  }
+
   XFreePixmap(display, drawable);
   XFreeGC(display, gc);
   XDestroyWindow(display, win);
@@ -134,44 +181,40 @@ void RpBar::init_socket() {
   }
 }
 
-void RpBar::init_font(const char *fontstr) {
-  // This function is pretty much copy+pasted from A. Garbe's dmenu
-  // (http://tools.suckless.org/dmenu)
-  if(!fontstr || fontstr[0] == '\0') {
-    std::stringstream ss; ss << "Can not load font " << fontstr;
-    throw RpBarException(ss.str());
+// init_font loads a single font, and sets up the FontConfig pattern so that
+// we can load additional fonts if necessary.
+void
+RpBar::init_font(const char *fontstr) {
+  if (!fontstr || strlen(fontstr) == 0) {
+    throw RpBarException("init_font called without a font string");
   }
-  char **missing = NULL;
-  char *def;
-  int i,n;
-  font.set = XCreateFontSet(display, fontstr, &missing, &n, &def);
-  if(missing) {
-    XFreeStringList(missing);
+
+  XftFont * xft_font = XftFontOpenName(display, screen, fontstr);
+  if (!xft_font) {
+    throw RpBarException("Font not found");
   }
-  if(font.set) {
-    //XFontSetExtents *font_extents;
-    XFontStruct **xfonts;
-    char **font_names;
-    font.ascent = font.descent = 0;
-    //font_extents = XExtentsOfFontSet(font.set);
-    n = XFontsOfFontSet(font.set, &xfonts, &font_names);
-    for(i = 0, font.ascent = 0, font.descent = 0; i < n; i++) {
-      if(font.ascent < (*xfonts)->ascent)
-        font.ascent = (*xfonts)->ascent;
-      if(font.descent < (*xfonts)->descent)
-        font.descent = (*xfonts)->descent;
-      xfonts++;
-    }
-  } else {
-    if(!(font.xfont = XLoadQueryFont(display, fontstr))
-       && !(font.xfont = XLoadQueryFont(display, "fixed"))) {
-      std::stringstream ss; ss << "Can not load font " << fontstr;
-      throw RpBarException(ss.str());
-    }
-    font.ascent = font.xfont->ascent;
-    font.descent = font.xfont->descent;
+  xft_fonts.push_back(xft_font);
+
+  fc_pattern = FcNameParse((FcChar8 *) fontstr);
+  if (!fc_pattern) {
+    throw RpBarException("Cannot parse font name to pattern");
   }
-  font.height = font.ascent + font.descent;
+}
+
+XftFont *
+RpBar::load_font_by_pattern(FcPattern * const pattern)
+{
+  if (!pattern) {
+    return NULL;
+  }
+  return XftFontOpenPattern(display, pattern);
+}
+
+int
+RpBar::get_font_height()
+{
+  const XftFont * const xft_font = xft_fonts[0];
+  return xft_font->ascent + xft_font->descent;
 }
 
 void RpBar::init_gui() {
@@ -185,14 +228,12 @@ void RpBar::init_gui() {
   XSetWindowAttributes window_attribs;
   bordercolor = get_color(RPBAR_BORDERCOLOR);
   bgcolor = get_color(RPBAR_BGCOLOR);
-  fgcolor = get_color(RPBAR_FGCOLOR);
   mainbgcolor = get_color(RPBAR_MAINBGCOLOR);
-  mainfgcolor = get_color(RPBAR_MAINFGCOLOR);
   init_font(RPBAR_FONT_STR);
   window_attribs.override_redirect = 1;
   window_attribs.background_pixmap = ParentRelative;
   window_attribs.event_mask = ExposureMask | ButtonPressMask;
-  bar_h = font.height + RPBAR_PADDING;
+  bar_h = get_font_height() + RPBAR_PADDING;
   bar_x = 0;
   bar_y = DisplayHeight(display, screen) - bar_h;
   bar_w = DisplayWidth(display, screen);
@@ -204,9 +245,6 @@ void RpBar::init_gui() {
                                                                      screen));
   gc = XCreateGC(display, root, 0, 0);
   XSetLineAttributes(display, gc, 1, LineSolid, CapButt, JoinMiter);
-  if (!font.set) {
-    XSetFont(display, gc, font.xfont->fid);
-  }
   XMapRaised(display, win);
   refresh();
   XSync(display, false);
@@ -289,39 +327,231 @@ void RpBar::refresh(){
       button_label.erase(button_label.length()-1);
     }
     // highlight current window
-    unsigned long bg, fg;
+    unsigned long bg;
+    const char * fg_color = NULL;
     if (last_char=='*') {
       bg = mainbgcolor;
-      fg = mainfgcolor;
+      fg_color = RPBAR_MAINFGCOLOR;
     } else {
       bg = bgcolor;
-      fg = fgcolor;
+      fg_color = RPBAR_FGCOLOR;
     }
+
     // shave off characters until the width is acceptable
-    while (text_width(button_label) >
-           (button_width - 2*RPBAR_BUTTON_MARGIN)) {
+    while (text_width(button_label.c_str()) >
+        button_width - 2*RPBAR_BUTTON_MARGIN) {
       button_label.erase(button_label.length()-1);
     }
+
     XSetForeground(display, gc, bg);
     // TODO handle this in a smarter way.
     int width = (itr==windows.end()-1)? bar_w - curx - 2 : button_width - 1;
     XFillRectangle(display, drawable, gc, curx+1, 1, width, bar_h-2);
-    int x = curx + (button_width - text_width(button_label))/2;
-    int y = (bar_h / 2) - (font.height / 2) + font.ascent;
-    //int y = 1 + ((bar_h-1) - font.height)/2;
-    //int y = RPBAR_PADDING/2 + font.ascent + 1;
-    XSetForeground(display, gc, fg);
-    if(font.set) {
-      XmbDrawString(display, drawable, font.set, gc, x, y,
-                    button_label.c_str(), button_label.length());
-    } else {
-      XDrawString(display, drawable, gc, x, y, button_label.c_str(),
-                  button_label.length());
-    }
+
+    int x = curx + (button_width - text_width(button_label.c_str()))/2;
+    int y = (bar_h / 2) - (get_font_height() / 2) + xft_fonts[0]->ascent;
+
+    const bool render = true;
+    draw_text(x, y, button_label.c_str(), fg_color, render);
+
     curx += button_width;
   }
   XCopyArea(display, drawable, win, gc, 0, 0, bar_w, bar_h, 0, 0);
   XFlush(display);
+}
+
+// draw_text serves two purposes.
+//
+// First, you can draw text to the screen by passing render true.
+//
+// Second, by passing render false, you can determine the actual width
+// the text would have if displayed.
+//
+// It returns the width of the text. It returns -1 on failure.
+int
+RpBar::draw_text(const int x, const int y, const char * const text,
+  const char * const color, const bool render)
+{
+  // color may be NULL. It's only relevant if we're rendering.
+  if (!text || strlen(text) == 0) {
+    return -1;
+  }
+  if (render && !color) {
+    return -1;
+  }
+
+  XftDraw * xft_draw = NULL;
+  XftColor xft_color;
+  memset(&xft_color, 0, sizeof(XftColor));
+
+  if (render) {
+    xft_draw = XftDrawCreate(display, drawable,
+        DefaultVisual(display, screen), DefaultColormap(display, screen));
+    if (!xft_draw) {
+      return -1;
+    }
+
+    if (!XftColorAllocName(display, DefaultVisual(display, screen),
+          DefaultColormap(display, screen), color, &xft_color)) {
+      XftDrawDestroy(xft_draw);
+      return -1;
+    }
+  }
+
+  int cur_x = x;
+
+  for (size_t i = 0; i < strlen(text); ) {
+    draw_character(xft_draw, xft_color, &cur_x, y, text, &i, render);
+  }
+
+  if (render) {
+    XftColorFree(display, DefaultVisual(display, screen),
+      DefaultColormap(display, screen), &xft_color);
+    XftDrawDestroy(xft_draw);
+  }
+
+  return cur_x-x;
+}
+
+bool
+RpBar::draw_character(XftDraw * xft_draw, const XftColor xft_color,
+  int * const x, const int y, const char * const text, size_t * const pos,
+  const bool render)
+{
+  // xft_draw is only required if we are rendering.
+  if (!text || strlen(text) == 0 || !x || !pos) {
+    return false;
+  }
+  if (render && !xft_draw) {
+    return false;
+  }
+
+  // Find the codepoint to draw.
+  // We do this so we can check if the font has it to draw.
+  long utf8codepoint = 0;
+  const int utf8charlen = utf8decode(text+*pos, &utf8codepoint, UTF_SIZ);
+
+  // Try to render the character in a font we've loaded.
+  for (std::vector<XftFont *>::iterator i = xft_fonts.begin();
+      i != xft_fonts.end();
+      i++)
+  {
+    XftFont * const xft_font = *i;
+
+    if (XftCharExists(display, xft_font, utf8codepoint)) {
+      if (render) {
+        XftDrawStringUtf8(xft_draw, &xft_color, xft_font, *x, y,
+            (FcChar8 *) text+*pos, utf8charlen);
+      }
+      *x += text_width_in_font(xft_font, text+*pos, utf8charlen);
+      *pos += utf8charlen;
+      return true;
+    }
+  }
+
+  // No font yet loaded has the character.
+  //
+  // We try to load another font that does have it and use that.
+  // We use the pattern we were given initially to find another font.
+  //
+  // If we can't load another font, or still cannot find the character, we
+  // currently skip over the character and draw nothing.
+
+  XftFont * new_font = load_font_for_codepoint(utf8codepoint);
+  if (!new_font) {
+    *pos += utf8charlen;
+    return false;
+  }
+
+  if (XftCharExists(display, new_font, utf8codepoint)) {
+    if (render) {
+      XftDrawStringUtf8(xft_draw, &xft_color, new_font, *x, y,
+          (FcChar8 *) text+*pos, utf8charlen);
+    }
+    *x += text_width_in_font(new_font, text+*pos, utf8charlen);
+    *pos += utf8charlen;
+    return true;
+  }
+
+  *pos += utf8charlen;
+
+  return false;
+}
+
+// load_font_for_codepoint attempts to load another font given the
+// codepoint. We use the instance provided font config pattern.
+//
+// You don't need to clean up the returned font. We keep it around in
+// the object and clean it up in our destructor.
+//
+// Note much of this is taken with dmenu's drw.c drw_text() as reference.
+XftFont *
+RpBar::load_font_for_codepoint(long codepoint)
+{
+  FcCharSet * fc_charset = FcCharSetCreate();
+  if (!fc_charset) {
+    return NULL;
+  }
+
+  if (!FcCharSetAddChar(fc_charset, codepoint)) {
+    FcCharSetDestroy(fc_charset);
+    return NULL;
+  }
+
+  FcPattern * fc_pattern_dup = FcPatternDuplicate(fc_pattern);
+  if (!fc_pattern_dup) {
+    FcCharSetDestroy(fc_charset);
+    return NULL;
+  }
+
+  if (!FcPatternAddCharSet(fc_pattern_dup, FC_CHARSET, fc_charset)) {
+    FcCharSetDestroy(fc_charset);
+    FcPatternDestroy(fc_pattern);
+    return NULL;
+  }
+
+  if (!FcPatternAddBool(fc_pattern_dup, FC_SCALABLE, FcTrue)) {
+    FcCharSetDestroy(fc_charset);
+    FcPatternDestroy(fc_pattern);
+    return NULL;
+  }
+
+  if (!FcConfigSubstitute(NULL, fc_pattern_dup, FcMatchPattern)) {
+    FcCharSetDestroy(fc_charset);
+    FcPatternDestroy(fc_pattern);
+    return NULL;
+  }
+
+  FcDefaultSubstitute(fc_pattern_dup);
+
+  FcResult fc_result;
+  memset(&fc_result, 0, sizeof(FcResult));
+
+  FcPattern * fc_pattern_match = XftFontMatch(display, screen, fc_pattern_dup,
+      &fc_result);
+  if (!fc_pattern_match) {
+    FcCharSetDestroy(fc_charset);
+    FcPatternDestroy(fc_pattern);
+    return NULL;
+  }
+
+  FcCharSetDestroy(fc_charset);
+  fc_charset = NULL;
+  FcPatternDestroy(fc_pattern_dup);
+  fc_pattern_dup = NULL;
+
+  XftFont * new_font = load_font_by_pattern(fc_pattern_match);
+  if (!new_font) {
+    FcPatternDestroy(fc_pattern_match);
+    return NULL;
+  }
+
+  FcPatternDestroy(fc_pattern_match);
+  fc_pattern_match = NULL;
+
+  xft_fonts.push_back(new_font);
+
+  return new_font;
 }
 
 void RpBar::select_window(int win_ix) {
@@ -344,7 +574,12 @@ void RpBar::select_window(int win_ix) {
 int main(int argc, const char *argv[]) {
   rpbar::RpBar rpbar;
   rpbar.run();
+
   // TODO catch exceptions? It wouldn't accomplish much.
   // Leaving them at least allows core dump examination.
+
+  FcConfig * const fc_config = FcConfigGetCurrent();
+  FcConfigDestroy(fc_config);
+
   return 0;
 }

--- a/rpbar.hh
+++ b/rpbar.hh
@@ -18,6 +18,7 @@
 #ifndef RPBAR_Y2DAPIQS
 #define RPBAR_Y2DAPIQS
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <unistd.h>
 
@@ -27,6 +28,8 @@
 #include <string>
 #include <vector>
 
+#include <fontconfig/fontconfig.h>
+#include <X11/Xft/Xft.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/keysym.h>
@@ -42,14 +45,6 @@ public:
     std::runtime_error(what_arg) { }
 };
 
-struct Font {
-  XFontStruct *xfont;
-  XFontSet set;
-  int ascent;
-  int descent;
-  int height;
-};
-
 class RpBar {
 public:
   RpBar() { }
@@ -61,17 +56,46 @@ private:
   RpBar& operator=(const RpBar& other);
 
   void init_socket();
-  void init_font(const char *fontstr);
+
+  void
+  init_font(const char *fontstr);
+
+  XftFont *
+  load_font_by_pattern(FcPattern * const);
+
+  int
+  get_font_height();
+
   void init_gui();
 
   void refresh();
+
+  int
+  draw_text(const int, const int, const char * const,
+    const char * const, const bool);
+
+  bool
+  draw_character(XftDraw *, const XftColor,
+    int * const, const int, const char * const, size_t * const,
+    const bool);
+
+  XftFont *
+  load_font_for_codepoint(long);
+
   void handle_fd();
   void handle_timeout();
   void handle_xev();
   void select_window(int win_ix);
 
   void get_rp_info();
-  int text_width(const std::string& text);
+
+  int
+  text_width_in_font(XftFont * const, const char * const,
+    const int);
+
+  int
+  text_width(const char * const);
+
   unsigned long get_color(const char *colstr);
 
   // this class does too much stuff.
@@ -87,12 +111,13 @@ private:
   std::vector<std::string> windows;
 
   // X stuff
-  Font font;
-	Drawable drawable;
-	GC gc;
+  Drawable drawable;
+  GC gc;
   Display *display;
   int screen;
   Window root, win;
+  std::vector<XftFont *> xft_fonts;
+  FcPattern * fc_pattern;
 };
 
 void rstrip(char *s);

--- a/settings.hh
+++ b/settings.hh
@@ -25,6 +25,6 @@
 #define RPBAR_MAINBGCOLOR           "#202020"
 #define RPBAR_MAINFGCOLOR           "#76ff00"
 
-#define RPBAR_FONT_STR              "-*-terminus-medium-r-normal-*-12-*-*-*-*-*-*-*"
+#define RPBAR_FONT_STR "monospace:size=10"
 
 #endif /* end of include guard: SETTINGS_N7KJ765I */


### PR DESCRIPTION
Hi,

I found that there were issues displaying certain characters. The program appeared to be handling UTF8 characters improperly. To resolve this I used Xft functions to draw the text for the buttons. As a bonus this also lets the bar use more fonts than before.

I tried for a while to resolve the problem through updates using Xlib functions, but eventually gave up. I did make some progress, but I could not get all characters working. For example, a browser title including `&#x2019;` or `&trade;` would corrupt the bar's title such that everything after the first occurrence would be hidden. My partial solution involved adding `setlocale(LC_ALL, "")`. I tried switching to `Xutf8DrawString()` as well. Even with these updates, certain characters would not display correctly (using terminus by the way). `&trade;` for example kept stubbornly displaying as `"b`.

Maybe there is a way to get it working with Xlib but I could not figure it out.

I went looking at dmenu's source as I saw you used it for a reference for some functionality. I found that they had in 2015 switched to using Xft for drawing text (and probably more). I decided to try doing the same. Initially I had some similar issues happening (some UTF8 encoded runes displaying as `n` in terminus). The key was the use of `XftCharExists()` and loading additional fonts if that returned false. This is basically the same thing dmenu is doing. I wondered if there is a similar thing we could do using Xlib, but have been unable to find similar functions.

I extracted some functions from dmenu, and used other parts from it as a reference but rewrote them. I put some straight copied code into `drw.{c,h}`.

Anyway this commit introduces additional dependencies which is not ideal but it is working nicely for me.

I'd be happy to change anything you like here.