### PR TITLE
Throw error if running ratpoison fails, and do not divide by zero

### DIFF
--- a/rpbar.cc
+++ b/rpbar.cc
@@ -307,7 +307,16 @@ void RpBar::get_rp_info() {
     rstrip(buffer);
     windows.push_back(std::string(buffer));
   }
-  pclose(stream);
+
+  int const status = pclose(stream);
+  if (status == -1) {
+    std::string error = "error starting ratpoison: " +
+      std::string(strerror(errno));
+    throw RpBarException(error);
+  }
+  if (status != 0) {
+    throw RpBarException("ratpoison exited with non-zero status");
+  }
 }
 
 void RpBar::refresh(){

--- a/rpbar.cc
+++ b/rpbar.cc
@@ -149,6 +149,9 @@ void RpBar::handle_xev() {
         break;
       case ButtonPress:
         // figure out which 'button' was pressed
+        if (bar_w == 0) {
+          break;
+        }
         win_ix = (ev.xbutton.x*windows.size())/bar_w;
         select_window(win_ix);
         break;
@@ -312,7 +315,10 @@ void RpBar::refresh(){
   XSetForeground(display, gc, bordercolor);
   XFillRectangle(display, drawable, gc, 0, 0, bar_w, bar_h);
 
-  int button_width = bar_w/windows.size();
+  int button_width = bar_w;
+  if (windows.size() != 0) {
+    button_width = bar_w/windows.size();
+  }
   int curx = 0;
 
   for (std::vector<std::string>::iterator itr = windows.begin();


### PR DESCRIPTION
I was running ratpoison from git and did not have it in my PATH, and rpbar was not running as expected. When I started ratpoison with rpbar listed to exec, rpbar would immediately crash. I found we were dividing by zero (the second case changed here). After fixing this rpbar would not crash, but did not show anything. I eventually figured out we were failing to call ratpoison because of my PATH mistake.

These changes hopefully will make figuring that out a little easier if something similar happens to anyone else!