### PR TITLE
implement RPBAR_TOP

### DIFF
--- a/rpbar.cc
+++ b/rpbar.cc
@@ -236,7 +236,7 @@ void RpBar::init_gui() {
   window_attribs.event_mask = ExposureMask | ButtonPressMask;
   bar_h = get_font_height() + RPBAR_PADDING;
   bar_x = 0;
-  bar_y = DisplayHeight(display, screen) - bar_h;
+  bar_y = RPBAR_TOP ? 0 : DisplayHeight(display, screen) - bar_h;
   bar_w = DisplayWidth(display, screen);
   win = XCreateWindow(display, root, bar_x, bar_y, bar_w, bar_h, 0,
                       DefaultDepth(display, screen), CopyFromParent,


### PR DESCRIPTION
I noticed that the rpbar placement¹ option was not actually implemented. This patch resolves this.

[1] - https://github.com/dimatura/rpbar/blob/f27e44456ce47e43beb0741339031ab06449b7d3/settings.hh#L10-L11