### PR TITLE
Implement multi-monitor/screen support

### DIFF
--- a/settings.hh
+++ b/settings.hh
@@ -10,6 +10,9 @@
 // to be used for whether rpbar is on top or bottom
 #define RPBAR_TOP                   1
 
+// the RATPOISON screen(aka monitor) to display the bar on
+#define RPBAR_SCREEN                0
+
 // padding around text (top and bottom)
 #define RPBAR_PADDING               4
 // for communication with ratpoison. Bigger shouldn't hurt.


### PR DESCRIPTION
This sets the correct offsets for Rat Poison [screens](https://www.nongnu.org/ratpoison/doc/Multiple-Screens.html#Multiple-Screens), which essentially act as monitors(ex: screen 0 = left monitor, screen 1 = right monitor). 

It reads in screen info via a Rat Poison command and runs it through some regex to get the correct numbers. The code is pretty messy, let me know if I should change anything.