### PR TITLE
Status bar

### DIFF
--- a/rpbar.cc
+++ b/rpbar.cc
@@ -36,11 +36,34 @@
 
 #include <algorithm>
 
+#include <X11/Xatom.h>
+
 #include "drw.h"
 
 namespace rpbar
 {
+// shamelessly stolen from dwm.c
+int gettextprop(Display *dpy, Window w, Atom atom, char *text, unsigned int size)
+{
+	char **list = NULL;
+	int n;
+	XTextProperty name;
 
+	if (!text || size == 0)
+		return 0;
+	text[0] = '\0';
+	if (!XGetTextProperty(dpy, w, &name, atom) || !name.nitems)
+		return 0;
+	if (name.encoding == XA_STRING) {
+		strncpy(text, (char *)name.value, size - 1);
+	} else if (XmbTextPropertyToTextList(dpy, &name, &list, &n) >= Success && n > 0 && *list) {
+		strncpy(text, *list, size - 1);
+		XFreeStringList(list);
+	}
+	text[size - 1] = '\0';
+	XFree(name.value);
+	return 1;
+}
 unsigned long RpBar::get_color(const char *colstr) {
   Colormap cmap = DefaultColormap(display, screen);
   XColor color;
@@ -230,14 +253,17 @@ void RpBar::init_gui() {
   bordercolor = get_color(RPBAR_BORDERCOLOR);
   bgcolor = get_color(RPBAR_BGCOLOR);
   mainbgcolor = get_color(RPBAR_MAINBGCOLOR);
+  statusbgcolor = get_color(RPBAR_STATUSBGCOLOR);
   init_font(RPBAR_FONT_STR);
   window_attribs.override_redirect = 1;
   window_attribs.background_pixmap = ParentRelative;
   window_attribs.event_mask = ExposureMask | ButtonPressMask;
   bar_h = get_font_height() + RPBAR_PADDING;
+
   bar_x = 0;
   bar_y = DisplayHeight(display, screen) - bar_h;
   bar_w = DisplayWidth(display, screen);
+  update_status();
   win = XCreateWindow(display, root, bar_x, bar_y, bar_w, bar_h, 0,
                       DefaultDepth(display, screen), CopyFromParent,
                       DefaultVisual(display, screen), CWOverrideRedirect |
@@ -256,7 +282,14 @@ void RpBar::run() {
   init_socket();
   init_gui();
   struct timeval timeout;
+  char old_root_name[256], root_name[256];
   while (true) {
+    gettextprop(display, root, XA_WM_NAME, root_name, sizeof(root_name));
+    if (strcmp(old_root_name, root_name) != 0) {
+      strcpy(old_root_name, root_name);
+      update_status();
+      refresh();
+    }
     FD_ZERO(&fds);
     FD_SET(x11_fd, &fds);
     FD_SET(sock_fd, &fds);
@@ -312,7 +345,7 @@ void RpBar::refresh(){
   XSetForeground(display, gc, bordercolor);
   XFillRectangle(display, drawable, gc, 0, 0, bar_w, bar_h);
 
-  int button_width = bar_w/windows.size();
+  int button_width = faked_bar_w/windows.size();
   int curx = 0;
 
   for (std::vector<std::string>::iterator itr = windows.begin();
@@ -320,6 +353,7 @@ void RpBar::refresh(){
        ++itr) {
     std::string& button_label(*itr);
     char last_char = button_label[button_label.length()-1];
+
     // '*' -> main win
     // '+' -> 'alternate' win
     // '-' -> other
@@ -327,6 +361,7 @@ void RpBar::refresh(){
     if (last_char!='s') {
       button_label.erase(button_label.length()-1);
     }
+
     // highlight current window
     unsigned long bg;
     const char * fg_color = NULL;
@@ -356,9 +391,23 @@ void RpBar::refresh(){
     draw_text(x, y, button_label.c_str(), fg_color, render);
 
     curx += button_width;
+    if (itr==windows.end()-1) {
+      XSetForeground(display, gc, statusbgcolor);
+      XFillRectangle(display, drawable, gc, curx+1, 1, width, bar_h-2);
+      draw_text(curx + (text_width(status) / 4), y, status, RPBAR_STATUSFGCOLOR, render);
+    }
   }
   XCopyArea(display, drawable, win, gc, 0, 0, bar_w, bar_h, 0, 0);
   XFlush(display);
+}
+
+void RpBar::update_status(){
+  if (!gettextprop(display, root, XA_WM_NAME, status, sizeof(status)))
+	strcpy(status, "rpbar");
+
+  status_width = text_width(status);
+  status_width += status_width / 2;
+  faked_bar_w = bar_w - status_width;
 }
 
 // draw_text serves two purposes.

--- a/rpbar.hh
+++ b/rpbar.hh
@@ -69,6 +69,8 @@ private:
   void init_gui();
 
   void refresh();
+  // refresh() should be called after
+  void update_status();
 
   int
   draw_text(const int, const int, const char * const,
@@ -104,8 +106,9 @@ private:
   fd_set fds;
   std::string socket_path;
 
-  int bar_x, bar_y, bar_w, bar_h;
-  unsigned long bordercolor, bgcolor, fgcolor, mainbgcolor, mainfgcolor;
+  char status[256];
+  int bar_x, bar_y, status_width, faked_bar_w, bar_w, bar_h;
+  unsigned long bordercolor, bgcolor, fgcolor, mainbgcolor, mainfgcolor, statusbgcolor, statusfgcolor;
 
   char buffer[RPBAR_BUFSIZE];
   std::vector<std::string> windows;
@@ -120,6 +123,7 @@ private:
   FcPattern * fc_pattern;
 };
 
+int gettextprop(Window w, Atom atom, char *text, unsigned int size);
 void rstrip(char *s);
 void rpbarsend(int argc, const char *argv[]);
 

--- a/settings.hh
+++ b/settings.hh
@@ -24,6 +24,8 @@
 #define RPBAR_FGCOLOR               "#D0D0D0"
 #define RPBAR_MAINBGCOLOR           "#202020"
 #define RPBAR_MAINFGCOLOR           "#76ff00"
+#define RPBAR_STATUSBGCOLOR         "#D0D0D0"
+#define RPBAR_STATUSFGCOLOR         "#080808"
 
 #define RPBAR_FONT_STR "monospace:size=10"
 


### PR DESCRIPTION
Add functionality for a status bar in the right of the normal bar. Uses ``xsetroot`` to set status, identical to how DWM's status bar is set.